### PR TITLE
options are overrided by data-attributes

### DIFF
--- a/js/bootstrap-notify.js
+++ b/js/bootstrap-notify.js
@@ -22,7 +22,7 @@
     // Element collection
     this.$element = $(element);
     this.$note    = $('<div class="alert"></div>');
-    this.options  = $.extend(true, $.fn.notify.defaults, options);
+    this.options  = $.extend(true, $.fn.notify.defaults, $.extend(true, options, this.$element.data()));
 
     // Setup from options
     if(this.options.transition)
@@ -35,16 +35,14 @@
       this.$note.addClass('alert-' + this.options.type);
     else this.$note.addClass('alert-success');
 
-    if(!this.options.message && this.$element.data("message") !== '') // dom text
-      this.$note.html(this.$element.data("message"));
-    else 
-      if(typeof this.options.message === 'object')
+    if(this.options.message)
+      if(typeof this.options.message === 'string')
+        this.$note.html(this.options.message);
+      else if(typeof this.options.message === 'object')
         if(this.options.message.html)
           this.$note.html(this.options.message.html);
         else if(this.options.message.text)
           this.$note.text(this.options.message.text);
-      else 
-        this.$note.html(this.options.message);
 
     if(this.options.closable)
       var link = $('<a class="close pull-right" href="#">&times;</a>');


### PR DESCRIPTION
Still, we need to provide a string for "message" since I couldn't manage to get a object with "data-message-html" attribute (I get "messageHtml" variable).

update: Apparently, we need to provide a json string to fetch a object from: 
http://stackoverflow.com/questions/7410348/how-to-set-json-format-to-html5-data-attributes-in-the-jquery
I think `data-message="hello"` is sexier than `data-message='{"html": "hello"}'`
