### PR TITLE
Add alert-dismissable for Bootstrap 3 usage

### DIFF
--- a/js/bootstrap-notify.js
+++ b/js/bootstrap-notify.js
@@ -23,7 +23,7 @@
     this.$element = $(element);
     this.$note    = $('<div class="alert"></div>');
     if (this.options.closable) {
-        this.$note    = $('<div class="alert alert-dismissable"></div>');
+        this.$note.addClass('alert-dismissable');
     }
 
     // Setup from options


### PR DESCRIPTION
Bootstrap 3 requires the alerts to have a `alert-dismissable` class when it's closable.
This PR adds that class if `closable` is set to `true`.
