### PR TITLE
Fixing z-index of notifications

### DIFF
--- a/css/bootstrap-notify.css
+++ b/css/bootstrap-notify.css
@@ -1,5 +1,6 @@
 .notifications {
   position: fixed;
+  z-index: 9999;
 }
 
 /* Positioning */ 
@@ -26,6 +27,5 @@
 /* Notification Element */
 .notifications > div {
   position: relative;
-  z-index: 9999;
   margin: 5px 0px;
 }


### PR DESCRIPTION
I'm sure `z-index` should be set for the element with `position: fixed`, not it's children. Works perfect for me.
